### PR TITLE
rerun build for platforms

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -32,6 +32,7 @@ products = prefix -> [
     LibraryProduct(prefix, "libz", :libz),
 ]
 
+
 # Dependencies that must be installed before this package can be built
 dependencies = [
 ]


### PR DESCRIPTION
Seems like I can't open an issue? 
I'm depending on ZlibBuilder in:
https://github.com/SimonDanisch/LibpngBuilder/blob/master/build_tarballs.jl

And most platforms fail since it seems like ZlibBuilder  doesn't support that platform.. since they seem to be available, this must be a bug, or the naming changed in the last 9 days or so.
Let's try to rebuild and then see what happens?

cc: @keno 