### PR TITLE
Create the pkg-config file if missing

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -26,6 +26,25 @@ else
 fi
 
 make install ${EXTRA_MAKE_FLAGS} -j${nproc}
+
+if [[ ! -e ${prefix}/lib/pkgconfig/zlib.pc ]]; then
+    mkdir -p ${prefix}/lib/pkgconfig
+    cat << EOF > $prefix/lib/pkgconfig/zlib.pc
+prefix=${prefix}
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+sharedlibdir=\${libdir}
+includedir=\${prefix}/include
+
+Name: zlib
+Description: zlib compression library
+Version: 1.2.11
+
+Requires:
+Libs: -L\${libdir} -L\${sharedlibdir} -lz
+Cflags: -I\${includedir}
+EOF
+fi
 """
 
 # Build for ALL THE PLATFORMS!


### PR DESCRIPTION
The FreeBSD build doesn't have the pkg-config file, I don't know why (configuring with cmake doesn't produce one?  I'd find it strange :confused:).  I'm manually adding it anyway.